### PR TITLE
Enable support for UNIX sockets on all runtimes

### DIFF
--- a/src/Docker.DotNet.BasicAuth/Docker.DotNet.BasicAuth.csproj
+++ b/src/Docker.DotNet.BasicAuth/Docker.DotNet.BasicAuth.csproj
@@ -3,7 +3,7 @@
     <IsPackable>true</IsPackable>
     <PackageId>Docker.DotNet.BasicAuth</PackageId>
     <Description>Docker.DotNet.BasicAuth is a library that allows you to use basic authentication with a remote Docker engine programmatically in your .NET applications.</Description>
-    <TargetFrameworks>netstandard2.0;netstandard1.6;net46;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.6</TargetFrameworks>
     <AssemblyName>Docker.DotNet.BasicAuth</AssemblyName>
     <PackageIconUrl>https://camo.githubusercontent.com/fa6d5c12609ed8a3ba1163b96f9e9979b8f59b0d/687474703a2f2f7765732e696f2f566663732f636f6e74656e74</PackageIconUrl>
     <PackageLicenseUrl>https://github.com/Microsoft/Docker.DotNet/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/Docker.DotNet.X509/Docker.DotNet.X509.csproj
+++ b/src/Docker.DotNet.X509/Docker.DotNet.X509.csproj
@@ -3,7 +3,7 @@
     <IsPackable>true</IsPackable>
     <PackageId>Docker.DotNet.X509</PackageId>
     <Description>Docker.DotNet.X509 is a library that allows you to use certificate authentication with a remote Docker engine programmatically in your .NET applications.</Description>
-    <TargetFrameworks>netstandard2.0;netstandard1.6;net46;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.6</TargetFrameworks>
     <AssemblyName>Docker.DotNet.X509</AssemblyName>
     <PackageIconUrl>https://camo.githubusercontent.com/fa6d5c12609ed8a3ba1163b96f9e9979b8f59b0d/687474703a2f2f7765732e696f2f566663732f636f6e74656e74</PackageIconUrl>
     <PackageLicenseUrl>https://github.com/Microsoft/Docker.DotNet/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/Docker.DotNet/Docker.DotNet.csproj
+++ b/src/Docker.DotNet/Docker.DotNet.csproj
@@ -3,7 +3,7 @@
     <IsPackable>true</IsPackable>
     <PackageId>Docker.DotNet</PackageId>
     <Description>Docker.DotNet is a library that allows you to interact with the Docker Remote API programmatically with fully asynchronous, non-blocking and object-oriented code in your .NET applications.</Description>
-    <TargetFrameworks>net45;net46;netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
     <AssemblyName>Docker.DotNet</AssemblyName>
     <PackageIconUrl>https://camo.githubusercontent.com/fa6d5c12609ed8a3ba1163b96f9e9979b8f59b0d/687474703a2f2f7765732e696f2f566663732f636f6e74656e74</PackageIconUrl>
     <PackageLicenseUrl>https://github.com/Microsoft/Docker.DotNet/blob/master/LICENSE</PackageLicenseUrl>

--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -5,13 +5,10 @@ using System.IO.Pipes;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Net.Http.Client;
-
-#if (NETSTANDARD1_6 || NETSTANDARD2_0)
-using System.Net.Sockets;
-#endif
 
 namespace Docker.DotNet
 {
@@ -102,7 +99,6 @@ namespace Docker.DotNet
                     handler = new ManagedHandler();
                     break;
 
-#if (NETSTANDARD1_6 || NETSTANDARD2_0)
                 case "unix":
                     var pipeString = uri.LocalPath;
                     handler = new ManagedHandler(async (string host, int port, CancellationToken cancellationToken) =>
@@ -113,7 +109,6 @@ namespace Docker.DotNet
                     });
                     uri = new UriBuilder("http", uri.Segments.Last()).Uri;
                     break;
-#endif
 
                 default:
                     throw new Exception($"Unknown URL scheme {configuration.EndpointBaseUri.Scheme}");


### PR DESCRIPTION
.NET Framework applications are capable of connecting to UNIX sockets, and System.Net.Sockets ships as part of the .NET Framework. The Mono runtime supports .NET Framework applications on a cross-platform basis. I can't see a reason right now to not support UNIX socket URLs on all runtimes. 

Closes #322.