### PR TITLE
A cancellation doesn't work in some cases and app hangs.

### DIFF
--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -75,7 +75,11 @@ namespace Docker.DotNet
                         // NamedPipeClientStream handles file not found by polling until the server arrives. Use a short
                         // timeout so that the user doesn't get stuck waiting for a dockerd instance that is not running.
                         var timeout = 100; // 100ms
-                        var stream = new NamedPipeClientStream(serverName, pipeName);
+                        var stream = new NamedPipeClientStream(
+                            serverName,
+                            pipeName,
+                            PipeDirection.InOut,
+                            PipeOptions.Asynchronous);
                         var dockerStream = new DockerPipeStream(stream);
 
 #if NET45

--- a/src/Docker.DotNet/Microsoft.Net.Http.Client/BufferedReadStream.cs
+++ b/src/Docker.DotNet/Microsoft.Net.Http.Client/BufferedReadStream.cs
@@ -160,9 +160,11 @@ namespace Microsoft.Net.Http.Client
             {
                 _bufferOffset = 0;
                 _bufferCount = await _inner.ReadAsync(_buffer, _bufferOffset, _buffer.Length, cancel).ConfigureAwait(false);
+
+                ThrowIfDisposed();
+
                 if (_bufferCount == 0)
                 {
-                    ThrowIfDisposed();
                     throw new IOException("Unexpected end of stream");
                 }
             }

--- a/src/Docker.DotNet/Microsoft.Net.Http.Client/BufferedReadStream.cs
+++ b/src/Docker.DotNet/Microsoft.Net.Http.Client/BufferedReadStream.cs
@@ -162,6 +162,7 @@ namespace Microsoft.Net.Http.Client
                 _bufferCount = await _inner.ReadAsync(_buffer, _bufferOffset, _buffer.Length, cancel).ConfigureAwait(false);
                 if (_bufferCount == 0)
                 {
+                    ThrowIfDisposed();
                     throw new IOException("Unexpected end of stream");
                 }
             }

--- a/test/Docker.DotNet.Tests/ISystemOperations.Tests.cs
+++ b/test/Docker.DotNet.Tests/ISystemOperations.Tests.cs
@@ -90,6 +90,17 @@ namespace Docker.DotNet.Tests
             await _client.Images.DeleteImageAsync($"{repository}:{tag}", new ImageDeleteParameters());
         }
 
+        [Fact]
+        public async Task MonitorEventsAsync_EmptyContainersList_CanBeCancelled()
+        {
+            var cts = new CancellationTokenSource();
+            cts.CancelAfter(1000);
+
+            var task = _client.System.MonitorEventsAsync(new ContainerEventsParameters(), new Progress(), cts.Token);
+
+            await task;
+        }
+
         class Progress : IProgress<JSONMessage>
         {
             internal Action<JSONMessage> _onCalled;


### PR DESCRIPTION
I've played a little bit with an issue raised [here](https://github.com/Microsoft/Docker.DotNet/pull/343) it seems that without setting NamedPipeClientStream to PipeOptions.Asynchronous after disposing stream it endlessly waits in PipeStream.Read for local Windows connection.

Steps to repro:

create console app (NET71, .NETCORE) on Windows machine with empty Docker. 

        public static async Task Main(string[] args)
        {
            var cts = new CancellationTokenSource();

            var _client = new DockerClientConfiguration().CreateClient();
            cts.CancelAfter(3000);
            cts.Token.Register(() => { Console.WriteLine("Cancel happened"); });
            var task = _client.System.MonitorEventsAsync(new ContainerEventsParameters(), new Progress(), cts.Token);
            await task.ConfigureAwait(false);
            Console.WriteLine("finished");
            Console.ReadKey();
        }
        
        class Progress : IProgress<JSONMessage>
        {
            internal Action<JSONMessage> _onCalled;

            void IProgress<JSONMessage>.Report(JSONMessage value)
            {
                _onCalled(value);
            }
        }