### PR TITLE
X-Registry-Auth must be encoded to base64 url safe

### DIFF
--- a/src/Docker.DotNet/Endpoints/ImageOperations.cs
+++ b/src/Docker.DotNet/Endpoints/ImageOperations.cs
@@ -265,7 +265,14 @@ namespace Docker.DotNet
             {
                 {
                     RegistryAuthHeaderKey,
-                    Convert.ToBase64String(Encoding.UTF8.GetBytes(this._client.JsonSerializer.SerializeObject(authConfig ?? new AuthConfig())))
+                    Convert.ToBase64String(
+                        Encoding.UTF8.GetBytes(
+                            this._client.JsonSerializer.SerializeObject(authConfig ?? new AuthConfig())))
+                    .Replace("/", "_").Replace("+", "-") 
+                    // This is not documented in Docker API but from source code (https://github.com/docker/docker-ce/blob/10e40bd1548f69354a803a15fde1b672cc024b91/components/cli/cli/command/registry.go#L47)
+                    // and from multiple internet sources it has to be base64-url-safe. 
+                    // See RFC 4648 Section 5.
+                    // Padding (=) needs to be kept.
                 }
             };
         }


### PR DESCRIPTION
The documentation of docker api is incomplete for X-Registry-Auth. It should be base64 url safe.
Multiple sources in the internet can be found. 
[docker source](https://github.com/docker/docker-ce/blob/10e40bd1548f69354a803a15fde1b672cc024b91/components/cli/cli/command/registry.go#L47)
The documentation of the [Go package](https://godoc.org/encoding/base64#example-Encoding-EncodeToString) indicates that the encoding follows the alternate definition defined in RFC4648 in [section 5](https://tools.ietf.org/html/rfc4648#page-7) and that the padding is still required.