### PR TITLE
Added a json converter to deserialize base64 strings to a byte array

### DIFF
--- a/src/Docker.DotNet/JsonBase64Converter.cs
+++ b/src/Docker.DotNet/JsonBase64Converter.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Docker.DotNet
+{
+    internal class JsonBase64Converter : JsonConverter
+    {
+        public override bool CanRead => true;
+
+        public override bool CanWrite => false;
+
+        public override void WriteJson(JsonWriter writer, object value, Newtonsoft.Json.JsonSerializer serializer)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, Newtonsoft.Json.JsonSerializer serializer)
+        {
+            var strVal = reader.Value as string;
+
+            return Convert.FromBase64String(strVal);
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof (IList<byte>);
+        }
+    }
+}

--- a/src/Docker.DotNet/JsonSerializer.cs
+++ b/src/Docker.DotNet/JsonSerializer.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 
 namespace Docker.DotNet
@@ -17,7 +17,8 @@ namespace Docker.DotNet
                 new JsonVersionConverter(),
                 new StringEnumConverter(),
                 new TimeSpanSecondsConverter(),
-                new TimeSpanNanosecondsConverter()
+                new TimeSpanNanosecondsConverter(),
+                new JsonBase64Converter()
             }
         };
 


### PR DESCRIPTION
Fix for this issue https://github.com/dotnet/Docker.DotNet/issues/458

The only places in the models ILIst<byte> is used is in TLSInfo and SecretSpec.
TLSInfo is only ever received from the docker engine and the Data attribute in the SecretSpec model is only used when creating a secret so it never needs to be serialized. 
This means this change will not affect any other endpoint.