### PR TITLE
Added MultiplexedStreamReader

### DIFF
--- a/src/Docker.DotNet/MultiplexedStreamReader.cs
+++ b/src/Docker.DotNet/MultiplexedStreamReader.cs
@@ -14,7 +14,7 @@ namespace Docker.DotNet
             _stream = stream;
         }
 
-        public async Task<string> ReadLineAsync(CancellationToken token)
+        public async Task<string> ReadLineAsync(CancellationToken token = default)
         {
             var line = new List<byte>();
 

--- a/src/Docker.DotNet/MultiplexedStreamReader.cs
+++ b/src/Docker.DotNet/MultiplexedStreamReader.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Docker.DotNet
+{
+    public class MultiplexedStreamReader
+    {
+        private readonly MultiplexedStream _stream;
+
+        public MultiplexedStreamReader(MultiplexedStream stream)
+        {
+            _stream = stream;
+        }
+
+        public async Task<string> ReadLineAsync(CancellationToken token)
+        {
+            var line = new List<byte>();
+
+            var buffer = new byte[1];
+
+            while (true)
+            {
+                var res = await _stream.ReadOutputAsync(buffer, 0, 1, token);
+
+                if (res.Count == 0)
+                {
+                    continue;
+                }
+
+                else if (buffer[0] == '\n')
+                {
+                    return Encoding.UTF8.GetString(line.ToArray());
+                }
+
+                else
+                {
+                    line.Add(buffer[0]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added a simple reader for the multiplexed stream used for getting logs from containers which can read lines as strings. Also works with the service logs pull request i've made.
Ideally the multiplex stream would extend the stream class or something so we can use the normal stream reader but this is working for me.