### PR TITLE
CreateContainerAsync: Throw DockerImageNotFoundException when image not found

### DIFF
--- a/src/Docker.DotNet/Endpoints/ContainerOperations.cs
+++ b/src/Docker.DotNet/Endpoints/ContainerOperations.cs
@@ -20,6 +20,13 @@ namespace Docker.DotNet
                 throw new DockerContainerNotFoundException(statusCode, responseBody);
             }
         };
+        internal static readonly ApiResponseErrorHandlingDelegate NoSuchImageHandler = (statusCode, responseBody) =>
+        {
+            if (statusCode == HttpStatusCode.NotFound)
+            {
+                throw new DockerImageNotFoundException(statusCode, responseBody);
+            }
+        };
 
         private readonly DockerClient _client;
 
@@ -55,7 +62,7 @@ namespace Docker.DotNet
             }
 
             var data = new JsonRequestContent<CreateContainerParameters>(parameters, this._client.JsonSerializer);
-            var response = await this._client.MakeRequestAsync(new[] { NoSuchContainerHandler }, HttpMethod.Post, "containers/create", qs, data, cancellationToken).ConfigureAwait(false);
+            var response = await this._client.MakeRequestAsync(new[] { NoSuchImageHandler }, HttpMethod.Post, "containers/create", qs, data, cancellationToken).ConfigureAwait(false);
             return this._client.JsonSerializer.DeserializeObject<CreateContainerResponse>(response.Body);
         }
 

--- a/test/Docker.DotNet.Tests/IContainerOperationsTests.cs
+++ b/test/Docker.DotNet.Tests/IContainerOperationsTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Threading.Tasks;
+using Docker.DotNet.Models;
+using Xunit;
+
+namespace Docker.DotNet.Tests
+{
+	public class IContainerOperationsTests : IDisposable
+	{
+		private readonly DockerClient _client;
+
+		public IContainerOperationsTests()
+		{
+			_client = new DockerClientConfiguration().CreateClient();
+		}
+
+		[Fact]
+		public async Task CreateImageAsync_NonexistantImage_ThrowsDockerImageNotFoundException()
+		{
+			var parameters = new CreateContainerParameters
+			{
+				Image = "no-such-image-ytfghbkufhresdhtrjygvb",
+			};
+			Func<Task> op = async () => await _client.Containers.CreateContainerAsync(parameters);
+
+			await Assert.ThrowsAsync<DockerImageNotFoundException>(op);
+		}
+
+		public void Dispose()
+		{
+			_client.Dispose();
+		}
+	}
+}


### PR DESCRIPTION
`ContainerOperations.CreateContainerAsync` now throws `DockerImageNotFoundException` instead of `DockerContainerNotFoundException `when the image can't be found.