### PR TITLE
Dispose the response object in case of errors

### DIFF
--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -270,7 +270,7 @@ namespace Docker.DotNet
 
             await HandleAndDisposeIfErrorResponseAsync(response.StatusCode, response, errorHandlers);
 
-            return await response.Content.ReadAsStreamAsync().ConfigureAwait(true);
+            return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
         }
 
         internal async Task<HttpResponseMessage> MakeRequestForRawResponseAsync(


### PR DESCRIPTION
In the existing implementation on an error response an exception is thrown. Due to this the original response object is not disposed leaving connections open. This change specifically disposes the response object before an exception is thrown either by one of the handlers OR the generic dockerApiException.

NOTE: The callers could not be wrapped around a `using` statement due to the return of an async stream task.