### PR TITLE
Fix publishing script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,8 @@ jobs:
           DNF_CODESIGN_SECRET: ${{secrets.DNF_CODESIGN_SECRET}}
       - name: Push packages to NuGet.org
         run: |
-          dotnet nuget push ./packages/Docker.DotNet.*.nupkg -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
+          rm ./packages/*.symbols.nupkg
+          dotnet nuget push './packages/Docker.DotNet.*.nupkg' -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
       - name: Create Release
         uses: actions/create-release@master
         env:


### PR DESCRIPTION
This fixes a bug in the publish actions, where only the main package was published. I described it in https://github.com/dotnet/Docker.DotNet/issues/463#issuecomment-1020438376

Merging this fix and making a new release should fix all issues related to mismatched package versions:

https://github.com/dotnet/Docker.DotNet/issues/562
https://github.com/dotnet/Docker.DotNet/issues/482
https://github.com/dotnet/Docker.DotNet/issues/463
https://github.com/dotnet/Docker.DotNet/issues/546
