### PR TITLE
#554 Cannot hijack chunked or content length stream

### DIFF
--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+
 using Microsoft.Net.Http.Client;
 
 #if (NETSTANDARD1_6 || NETSTANDARD2_0)
@@ -424,7 +425,7 @@ namespace Docker.DotNet
 
             var request = new HttpRequestMessage(method, HttpUtility.BuildUri(_endpointBaseUri, this._requestedApiVersion, path, queryString));
 
-            request.Version = new Version(1, 1);
+            request.Version = this.Configuration.HttpVersion;
 
             request.Headers.Add("User-Agent", UserAgent);
 

--- a/src/Docker.DotNet/DockerClientConfiguration.cs
+++ b/src/Docker.DotNet/DockerClientConfiguration.cs
@@ -14,6 +14,8 @@ namespace Docker.DotNet
 
         public TimeSpan NamedPipeConnectTimeout { get; set; } = TimeSpan.FromMilliseconds(100);
 
+        public Version HttpVersion { get; set; } = new Version(1, 1); // Default Version, although rancher desktop requires 1.0 to avoid chunked encoding
+
         private static Uri LocalDockerUri()
         {
             var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
@@ -34,6 +36,7 @@ namespace Docker.DotNet
 
             Credentials = credentials ?? new AnonymousCredentials();
             EndpointBaseUri = endpoint;
+
             if (defaultTimeout != TimeSpan.Zero)
             {
                 if (defaultTimeout < Timeout.InfiniteTimeSpan)


### PR DESCRIPTION
…h Rancher Desktop ( http 1.0 doesn't allow chunked encoding )