### PR TITLE
fix(#554): Support chunked transfer encoding (HTTP 1.1)

### DIFF
--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -333,7 +333,9 @@ namespace Docker.DotNet
                 throw new NotSupportedException("message handler does not support hijacked streams");
             }
 
-            return content.HijackStream();
+            var stream = await content.ReadAsStreamAsync()
+                .ConfigureAwait(false);
+            return (WriteClosableStream)stream;
         }
 
         private async Task<HttpResponseMessage> PrivateMakeRequestAsync(

--- a/src/Docker.DotNet/Microsoft.Net.Http.Client/ChunkedReadStream.cs
+++ b/src/Docker.DotNet/Microsoft.Net.Http.Client/ChunkedReadStream.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Net.Http.Client
 {
-    internal class ChunkedReadStream : Stream
+    internal class ChunkedReadStream : WriteClosableStream
     {
         private readonly BufferedReadStream _inner;
         private long _chunkBytesRemaining;
@@ -175,6 +175,14 @@ namespace Microsoft.Net.Http.Client
         public override void Flush()
         {
             throw new NotSupportedException();
+        }
+
+        public override bool CanCloseWrite
+            => _inner.CanCloseWrite;
+
+        public override void CloseWrite()
+        {
+            _inner.CloseWrite();
         }
     }
 }


### PR DESCRIPTION
@galvesribeiro This pull request contains the changes to support the chunked transfer encoding and closes #566 and #554.