### PR TITLE
Feature/add http custom headers

### DIFF
--- a/src/Docker.DotNet/DockerApiStreamedResponse.cs
+++ b/src/Docker.DotNet/DockerApiStreamedResponse.cs
@@ -4,19 +4,19 @@ using System.Net.Http.Headers;
 
 namespace Docker.DotNet
 {
-    internal class DockerApiStreamedResponse
+    internal sealed class DockerApiStreamedResponse
     {
-        public HttpStatusCode StatusCode { get; private set; }
-
-        public Stream Body { get; private set; }
-
-        public HttpResponseHeaders Headers { get; private set; }
-
         public DockerApiStreamedResponse(HttpStatusCode statusCode, Stream body, HttpResponseHeaders headers)
         {
-            this.StatusCode = statusCode;
-            this.Body = body;
-            this.Headers = headers;
+            StatusCode = statusCode;
+            Body = body;
+            Headers = headers;
         }
+
+        public HttpStatusCode StatusCode { get; }
+
+        public Stream Body { get; }
+
+        public HttpResponseHeaders Headers { get; }
     }
 }

--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -393,12 +393,13 @@ namespace Docker.DotNet
             request.Version = new Version(1, 1);
             request.Headers.Add("User-Agent", UserAgent);
 
-            if (headers != null)
+            var customHeaders = headers == null
+                ? Configuration.DefaultHttpRequestHeaders
+                : Configuration.DefaultHttpRequestHeaders.Concat(headers);
+
+            foreach (var header in customHeaders)
             {
-                foreach (var header in headers)
-                {
-                    request.Headers.Add(header.Key, header.Value);
-                }
+                request.Headers.Add(header.Key, header.Value);
             }
 
             if (data != null)

--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -5,35 +5,35 @@ using System.IO.Pipes;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Net.Http.Client;
-
-#if (NETSTANDARD1_6 || NETSTANDARD2_0)
-using System.Net.Sockets;
-#endif
 
 namespace Docker.DotNet
 {
     public sealed class DockerClient : IDockerClient
     {
+        internal readonly IEnumerable<ApiResponseErrorHandlingDelegate> NoErrorHandlers = Enumerable.Empty<ApiResponseErrorHandlingDelegate>();
+
         private const string UserAgent = "Docker.DotNet";
 
-        private static readonly TimeSpan s_InfiniteTimeout = TimeSpan.FromMilliseconds(Timeout.Infinite);
+        private static readonly TimeSpan SInfiniteTimeout = Timeout.InfiniteTimeSpan;
 
         private readonly HttpClient _client;
 
         private readonly Uri _endpointBaseUri;
 
-        internal readonly IEnumerable<ApiResponseErrorHandlingDelegate> NoErrorHandlers = Enumerable.Empty<ApiResponseErrorHandlingDelegate>();
         private readonly Version _requestedApiVersion;
 
         internal DockerClient(DockerClientConfiguration configuration, Version requestedApiVersion)
         {
-            Configuration = configuration;
             _requestedApiVersion = requestedApiVersion;
-            JsonSerializer = new JsonSerializer();
 
+            Configuration = configuration;
+            DefaultTimeout = configuration.DefaultTimeout;
+
+            JsonSerializer = new JsonSerializer();
             Images = new ImageOperations(this);
             Containers = new ContainerOperations(this);
             System = new SystemOperations(this);
@@ -73,15 +73,13 @@ namespace Docker.DotNet
                     uri = new UriBuilder("http", pipeName).Uri;
                     handler = new ManagedHandler(async (host, port, cancellationToken) =>
                     {
-                        int timeout = (int)this.Configuration.NamedPipeConnectTimeout.TotalMilliseconds;
+                        var timeout = (int)Configuration.NamedPipeConnectTimeout.TotalMilliseconds;
                         var stream = new NamedPipeClientStream(serverName, pipeName, PipeDirection.InOut, PipeOptions.Asynchronous);
                         var dockerStream = new DockerPipeStream(stream);
 
-#if NET45
-                        await Task.Run(() => stream.Connect(timeout), cancellationToken);
-#else
-                        await stream.ConnectAsync(timeout, cancellationToken);
-#endif
+                        await stream.ConnectAsync(timeout, cancellationToken)
+                            .ConfigureAwait(false);
+
                         return dockerStream;
                     });
 
@@ -101,18 +99,19 @@ namespace Docker.DotNet
                     handler = new ManagedHandler();
                     break;
 
-#if (NETSTANDARD1_6 || NETSTANDARD2_0)
                 case "unix":
                     var pipeString = uri.LocalPath;
-                    handler = new ManagedHandler(async (string host, int port, CancellationToken cancellationToken) =>
+                    handler = new ManagedHandler(async (host, port, cancellationToken) =>
                     {
                         var sock = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
-                        await sock.ConnectAsync(new UnixDomainSocketEndPoint(pipeString));
+
+                        await sock.ConnectAsync(new Microsoft.Net.Http.Client.UnixDomainSocketEndPoint(pipeString))
+                            .ConfigureAwait(false);
+
                         return sock;
                     });
                     uri = new UriBuilder("http", uri.Segments.Last()).Uri;
                     break;
-#endif
 
                 default:
                     throw new Exception($"Unknown URL scheme {configuration.EndpointBaseUri.Scheme}");
@@ -121,8 +120,7 @@ namespace Docker.DotNet
             _endpointBaseUri = uri;
 
             _client = new HttpClient(Configuration.Credentials.GetHandler(handler), true);
-            DefaultTimeout = Configuration.DefaultTimeout;
-            _client.Timeout = s_InfiniteTimeout;
+            _client.Timeout = SInfiniteTimeout;
         }
 
         public DockerClientConfiguration Configuration { get; }
@@ -150,6 +148,11 @@ namespace Docker.DotNet
         public IExecOperations Exec { get; }
 
         internal JsonSerializer JsonSerializer { get; }
+
+        public void Dispose()
+        {
+            Configuration.Dispose();
+        }
 
         internal Task<DockerApiResponse> MakeRequestAsync(
             IEnumerable<ApiResponseErrorHandlingDelegate> errorHandlers,
@@ -190,7 +193,7 @@ namespace Docker.DotNet
             IDictionary<string, string> headers,
             CancellationToken token)
         {
-            return MakeRequestAsync(errorHandlers, method, path, queryString, body, headers, this.DefaultTimeout, token);
+            return MakeRequestAsync(errorHandlers, method, path, queryString, body, headers, DefaultTimeout, token);
         }
 
         internal async Task<DockerApiResponse> MakeRequestAsync(
@@ -203,12 +206,16 @@ namespace Docker.DotNet
             TimeSpan timeout,
             CancellationToken token)
         {
-            var response = await PrivateMakeRequestAsync(timeout, HttpCompletionOption.ResponseContentRead, method, path, queryString, headers, body, token).ConfigureAwait(false);
+            var response = await PrivateMakeRequestAsync(timeout, HttpCompletionOption.ResponseContentRead, method, path, queryString, headers, body, token)
+                .ConfigureAwait(false);
+
             using (response)
             {
-                await HandleIfErrorResponseAsync(response.StatusCode, response, errorHandlers);
+                await HandleIfErrorResponseAsync(response.StatusCode, response, errorHandlers)
+                    .ConfigureAwait(false);
 
-                var responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                var responseBody = await response.Content.ReadAsStringAsync()
+                    .ConfigureAwait(false);
 
                 return new DockerApiResponse(response.StatusCode, responseBody);
             }
@@ -253,7 +260,7 @@ namespace Docker.DotNet
             IDictionary<string, string> headers,
             CancellationToken token)
         {
-            return MakeRequestForStreamAsync(errorHandlers, method, path, queryString, body, headers, s_InfiniteTimeout, token);
+            return MakeRequestForStreamAsync(errorHandlers, method, path, queryString, body, headers, SInfiniteTimeout, token);
         }
 
         internal async Task<Stream> MakeRequestForStreamAsync(
@@ -266,14 +273,17 @@ namespace Docker.DotNet
             TimeSpan timeout,
             CancellationToken token)
         {
-            var response = await PrivateMakeRequestAsync(timeout, HttpCompletionOption.ResponseHeadersRead, method, path, queryString, headers, body, token).ConfigureAwait(false);
+            var response = await PrivateMakeRequestAsync(timeout, HttpCompletionOption.ResponseHeadersRead, method, path, queryString, headers, body, token)
+                .ConfigureAwait(false);
 
-            await HandleIfErrorResponseAsync(response.StatusCode, response, errorHandlers);
+            await HandleIfErrorResponseAsync(response.StatusCode, response, errorHandlers)
+                .ConfigureAwait(false);
 
-            return await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+            return await response.Content.ReadAsStreamAsync()
+                .ConfigureAwait(false);
         }
 
-        internal async Task<HttpResponseMessage> MakeRequestForRawResponseAsync(
+        internal Task<HttpResponseMessage> MakeRequestForRawResponseAsync(
             HttpMethod method,
             string path,
             IQueryString queryString,
@@ -281,8 +291,7 @@ namespace Docker.DotNet
             IDictionary<string, string> headers,
             CancellationToken token)
         {
-            var response = await PrivateMakeRequestAsync(s_InfiniteTimeout, HttpCompletionOption.ResponseHeadersRead, method, path, queryString, headers, body, token).ConfigureAwait(false);
-            return response;
+            return PrivateMakeRequestAsync(SInfiniteTimeout, HttpCompletionOption.ResponseHeadersRead, method, path, queryString, headers, body, token);
         }
 
         internal async Task<DockerApiStreamedResponse> MakeRequestForStreamedResponseAsync(
@@ -292,11 +301,14 @@ namespace Docker.DotNet
             IQueryString queryString,
             CancellationToken cancellationToken)
         {
-            var response = await PrivateMakeRequestAsync(s_InfiniteTimeout, HttpCompletionOption.ResponseHeadersRead, method, path, queryString, null, null, cancellationToken);
+            var response = await PrivateMakeRequestAsync(SInfiniteTimeout, HttpCompletionOption.ResponseHeadersRead, method, path, queryString, null, null, cancellationToken)
+                .ConfigureAwait(false);
 
-            await HandleIfErrorResponseAsync(response.StatusCode, response, errorHandlers);
+            await HandleIfErrorResponseAsync(response.StatusCode, response, errorHandlers)
+                .ConfigureAwait(false);
 
-            var body = await response.Content.ReadAsStreamAsync();
+            var body = await response.Content.ReadAsStreamAsync()
+                .ConfigureAwait(false);
 
             return new DockerApiStreamedResponse(response.StatusCode, body, response.Headers);
         }
@@ -310,7 +322,7 @@ namespace Docker.DotNet
             IDictionary<string, string> headers,
             CancellationToken cancellationToken)
         {
-            return MakeRequestForHijackedStreamAsync(errorHandlers, method, path, queryString, body, headers, s_InfiniteTimeout, cancellationToken);
+            return MakeRequestForHijackedStreamAsync(errorHandlers, method, path, queryString, body, headers, SInfiniteTimeout, cancellationToken);
         }
 
         internal async Task<WriteClosableStream> MakeRequestForHijackedStreamAsync(
@@ -323,18 +335,20 @@ namespace Docker.DotNet
             TimeSpan timeout,
             CancellationToken cancellationToken)
         {
-            var response = await PrivateMakeRequestAsync(timeout, HttpCompletionOption.ResponseHeadersRead, method, path, queryString, headers, body, cancellationToken).ConfigureAwait(false);
+            var response = await PrivateMakeRequestAsync(timeout, HttpCompletionOption.ResponseHeadersRead, method, path, queryString, headers, body, cancellationToken)
+                .ConfigureAwait(false);
 
-            await HandleIfErrorResponseAsync(response.StatusCode, response, errorHandlers);
+            await HandleIfErrorResponseAsync(response.StatusCode, response, errorHandlers)
+                .ConfigureAwait(false);
 
-            var content = response.Content as HttpConnectionResponseContent;
-            if (content == null)
+            if (!(response.Content is HttpConnectionResponseContent content))
             {
                 throw new NotSupportedException("message handler does not support hijacked streams");
             }
 
             var stream = await content.ReadAsStreamAsync()
                 .ConfigureAwait(false);
+
             return (WriteClosableStream)stream;
         }
 
@@ -350,70 +364,21 @@ namespace Docker.DotNet
         {
             var request = PrepareRequest(method, path, queryString, headers, data);
 
-            if (timeout != s_InfiniteTimeout)
+            if (timeout != SInfiniteTimeout)
             {
                 using (var timeoutTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken))
                 {
                     timeoutTokenSource.CancelAfter(timeout);
-                    return await _client.SendAsync(request, completionOption, timeoutTokenSource.Token).ConfigureAwait(false);
+                    return await _client.SendAsync(request, completionOption, timeoutTokenSource.Token)
+                        .ConfigureAwait(false);
                 }
             }
 
             var tcs = new TaskCompletionSource<HttpResponseMessage>();
             using (cancellationToken.Register(() => tcs.SetCanceled()))
             {
-                return await await Task.WhenAny(tcs.Task, _client.SendAsync(request, completionOption, cancellationToken)).ConfigureAwait(false);
-            }
-        }
-
-        private async Task HandleIfErrorResponseAsync(HttpStatusCode statusCode, HttpResponseMessage response, IEnumerable<ApiResponseErrorHandlingDelegate> handlers)
-        {
-            bool isErrorResponse = statusCode < HttpStatusCode.OK || statusCode >= HttpStatusCode.BadRequest;
-
-            string responseBody = null;
-
-            if (isErrorResponse)
-            {
-                // If it is not an error response, we do not read the response body because the caller may wish to consume it.
-                // If it is an error response, we do because there is nothing else going to be done with it anyway and
-                // we want to report the response body in the error message as it contains potentially useful info.
-                responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            }
-
-            // If no customer handlers just default the response.
-            if (handlers != null)
-            {
-                foreach (var handler in handlers)
-                {
-                    handler(statusCode, responseBody);
-                }
-            }
-
-            // No custom handler was fired. Default the response for generic success/failures.
-            if (isErrorResponse)
-            {
-                throw new DockerApiException(statusCode, responseBody);
-            }
-        }
-
-        public async Task HandleIfErrorResponseAsync(HttpStatusCode statusCode, HttpResponseMessage response)
-        {
-            bool isErrorResponse = statusCode < HttpStatusCode.OK || statusCode >= HttpStatusCode.BadRequest;
-
-            string responseBody = null;
-
-            if (isErrorResponse)
-            {
-                // If it is not an error response, we do not read the response body because the caller may wish to consume it.
-                // If it is an error response, we do because there is nothing else going to be done with it anyway and
-                // we want to report the response body in the error message as it contains potentially useful info.
-                responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            }
-
-            // No custom handler was fired. Default the response for generic success/failures.
-            if (isErrorResponse)
-            {
-                throw new DockerApiException(statusCode, responseBody);
+                return await await Task.WhenAny(tcs.Task, _client.SendAsync(request, completionOption, cancellationToken))
+                    .ConfigureAwait(false);
             }
         }
 
@@ -424,10 +389,8 @@ namespace Docker.DotNet
                 throw new ArgumentNullException(nameof(path));
             }
 
-            var request = new HttpRequestMessage(method, HttpUtility.BuildUri(_endpointBaseUri, this._requestedApiVersion, path, queryString));
-
+            var request = new HttpRequestMessage(method, HttpUtility.BuildUri(_endpointBaseUri, _requestedApiVersion, path, queryString));
             request.Version = new Version(1, 1);
-
             request.Headers.Add("User-Agent", UserAgent);
 
             if (headers != null)
@@ -447,9 +410,57 @@ namespace Docker.DotNet
             return request;
         }
 
-        public void Dispose()
+        private async Task HandleIfErrorResponseAsync(HttpStatusCode statusCode, HttpResponseMessage response, IEnumerable<ApiResponseErrorHandlingDelegate> handlers)
         {
-            Configuration.Dispose();
+            var isErrorResponse = statusCode < HttpStatusCode.OK || statusCode >= HttpStatusCode.BadRequest;
+
+            string responseBody = null;
+
+            if (isErrorResponse)
+            {
+                // If it is not an error response, we do not read the response body because the caller may wish to consume it.
+                // If it is an error response, we do because there is nothing else going to be done with it anyway and
+                // we want to report the response body in the error message as it contains potentially useful info.
+                responseBody = await response.Content.ReadAsStringAsync()
+                    .ConfigureAwait(false);
+            }
+
+            // If no customer handlers just default the response.
+            if (handlers != null)
+            {
+                foreach (var handler in handlers)
+                {
+                    handler(statusCode, responseBody);
+                }
+            }
+
+            // No custom handler was fired. Default the response for generic success/failures.
+            if (isErrorResponse)
+            {
+                throw new DockerApiException(statusCode, responseBody);
+            }
+        }
+
+        private async Task HandleIfErrorResponseAsync(HttpStatusCode statusCode, HttpResponseMessage response)
+        {
+            var isErrorResponse = statusCode < HttpStatusCode.OK || statusCode >= HttpStatusCode.BadRequest;
+
+            string responseBody = null;
+
+            if (isErrorResponse)
+            {
+                // If it is not an error response, we do not read the response body because the caller may wish to consume it.
+                // If it is an error response, we do because there is nothing else going to be done with it anyway and
+                // we want to report the response body in the error message as it contains potentially useful info.
+                responseBody = await response.Content.ReadAsStringAsync()
+                    .ConfigureAwait(false);
+            }
+
+            // No custom handler was fired. Default the response for generic success/failures.
+            if (isErrorResponse)
+            {
+                throw new DockerApiException(statusCode, responseBody);
+            }
         }
     }
 

--- a/src/Docker.DotNet/DockerClientConfiguration.cs
+++ b/src/Docker.DotNet/DockerClientConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -6,12 +7,21 @@ namespace Docker.DotNet
 {
     public class DockerClientConfiguration : IDisposable
     {
-        public DockerClientConfiguration(Credentials credentials = null, TimeSpan defaultTimeout = default)
-            : this(GetLocalDockerEndpoint(), credentials, defaultTimeout)
+        public DockerClientConfiguration(
+            Credentials credentials = null,
+            TimeSpan defaultTimeout = default,
+            TimeSpan namedPipeConnectTimeout = default,
+            IReadOnlyDictionary<string, string> defaultHttpRequestHeaders = null)
+            : this(GetLocalDockerEndpoint(), credentials, defaultTimeout, namedPipeConnectTimeout, defaultHttpRequestHeaders)
         {
         }
 
-        public DockerClientConfiguration(Uri endpoint, Credentials credentials = null, TimeSpan defaultTimeout = default)
+        public DockerClientConfiguration(
+            Uri endpoint,
+            Credentials credentials = null,
+            TimeSpan defaultTimeout = default,
+            TimeSpan namedPipeConnectTimeout = default,
+            IReadOnlyDictionary<string, string> defaultHttpRequestHeaders = null)
         {
             if (endpoint == null)
             {
@@ -23,21 +33,17 @@ namespace Docker.DotNet
                 throw new ArgumentException("Default timeout must be greater than -1", nameof(defaultTimeout));
             }
 
-            if (credentials == null)
-            {
-                credentials = new AnonymousCredentials();
-            }
-
-            if (defaultTimeout == default)
-            {
-                defaultTimeout = TimeSpan.FromSeconds(100);
-            }
-
             EndpointBaseUri = endpoint;
-            Credentials = credentials;
-            DefaultTimeout = defaultTimeout;
-            NamedPipeConnectTimeout = TimeSpan.FromMilliseconds(100);
+            Credentials = credentials ?? new AnonymousCredentials();
+            DefaultTimeout = TimeSpan.Equals(default, defaultTimeout) ? TimeSpan.FromSeconds(100) : defaultTimeout;
+            NamedPipeConnectTimeout = TimeSpan.Equals(default, namedPipeConnectTimeout) ? TimeSpan.FromMilliseconds(100) : namedPipeConnectTimeout;
+            DefaultHttpRequestHeaders = defaultHttpRequestHeaders ?? new Dictionary<string, string>();
         }
+
+        /// <summary>
+        /// Gets the collection of default HTTP request headers.
+        /// </summary>
+        public IReadOnlyDictionary<string, string> DefaultHttpRequestHeaders { get; }
 
         public Uri EndpointBaseUri { get; }
 
@@ -45,7 +51,7 @@ namespace Docker.DotNet
 
         public TimeSpan DefaultTimeout { get; }
 
-        public TimeSpan NamedPipeConnectTimeout { get; set; }
+        public TimeSpan NamedPipeConnectTimeout { get; }
 
         public DockerClient CreateClient(Version requestedApiVersion = null)
         {

--- a/src/Docker.DotNet/DockerClientConfiguration.cs
+++ b/src/Docker.DotNet/DockerClientConfiguration.cs
@@ -6,50 +6,48 @@ namespace Docker.DotNet
 {
     public class DockerClientConfiguration : IDisposable
     {
-        public Uri EndpointBaseUri { get; internal set; }
-
-        public Credentials Credentials { get; internal set; }
-
-        public TimeSpan DefaultTimeout { get; internal set; } = TimeSpan.FromSeconds(100);
-
-        public TimeSpan NamedPipeConnectTimeout { get; set; } = TimeSpan.FromMilliseconds(100);
-
-        private static Uri LocalDockerUri()
-        {
-            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
-            return isWindows ? new Uri("npipe://./pipe/docker_engine") : new Uri("unix:/var/run/docker.sock");
-        }
-
-        public DockerClientConfiguration(Credentials credentials = null, TimeSpan defaultTimeout = default(TimeSpan))
-            : this(LocalDockerUri(), credentials, defaultTimeout)
+        public DockerClientConfiguration(Credentials credentials = null, TimeSpan defaultTimeout = default)
+            : this(GetLocalDockerEndpoint(), credentials, defaultTimeout)
         {
         }
 
-        public DockerClientConfiguration(Uri endpoint, Credentials credentials = null,
-            TimeSpan defaultTimeout = default(TimeSpan))
+        public DockerClientConfiguration(Uri endpoint, Credentials credentials = null, TimeSpan defaultTimeout = default)
         {
             if (endpoint == null)
-                throw new ArgumentNullException(nameof(endpoint));
-
-
-            Credentials = credentials ?? new AnonymousCredentials();
-            EndpointBaseUri = endpoint;
-            if (defaultTimeout != TimeSpan.Zero)
             {
-                if (defaultTimeout < Timeout.InfiniteTimeSpan)
-                    // TODO: Should be a resource for localization.
-                    // TODO: Is this a good message?
-                    throw new ArgumentException("Timeout must be greater than Timeout.Infinite", nameof(defaultTimeout));
-                DefaultTimeout = defaultTimeout;
+                throw new ArgumentNullException(nameof(endpoint));
             }
+
+            if (defaultTimeout < Timeout.InfiniteTimeSpan)
+            {
+                throw new ArgumentException("Default timeout must be greater than -1", nameof(defaultTimeout));
+            }
+
+            if (credentials == null)
+            {
+                credentials = new AnonymousCredentials();
+            }
+
+            if (defaultTimeout == default)
+            {
+                defaultTimeout = TimeSpan.FromSeconds(100);
+            }
+
+            EndpointBaseUri = endpoint;
+            Credentials = credentials;
+            DefaultTimeout = defaultTimeout;
+            NamedPipeConnectTimeout = TimeSpan.FromMilliseconds(100);
         }
 
-        public DockerClient CreateClient()
-        {
-            return this.CreateClient(null);
-        }
+        public Uri EndpointBaseUri { get; }
 
-        public DockerClient CreateClient(Version requestedApiVersion)
+        public Credentials Credentials { get; }
+
+        public TimeSpan DefaultTimeout { get; }
+
+        public TimeSpan NamedPipeConnectTimeout { get; set; }
+
+        public DockerClient CreateClient(Version requestedApiVersion = null)
         {
             return new DockerClient(this, requestedApiVersion);
         }
@@ -57,6 +55,12 @@ namespace Docker.DotNet
         public void Dispose()
         {
             Credentials.Dispose();
+        }
+
+        private static Uri GetLocalDockerEndpoint()
+        {
+            var isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            return isWindows ? new Uri("npipe://./pipe/docker_engine") : new Uri("unix:/var/run/docker.sock");
         }
     }
 }


### PR DESCRIPTION
@galvesribeiro this allows the clients to set custom HTTP request headers. Depending on the API endpoint, this allows to enable or configure further features.

The first commit refactors some basics. It orders properties, methods, etc. by their modifier and applies `ConfigureAwait` to each await task.

The second commit adds the ability to set custom HTTP headers.