### PR TITLE
Fix #518, #522

### DIFF
--- a/src/Docker.DotNet/DockerClient.cs
+++ b/src/Docker.DotNet/DockerClient.cs
@@ -151,6 +151,7 @@ namespace Docker.DotNet
         public void Dispose()
         {
             Configuration.Dispose();
+            _client.Dispose();
         }
 
         internal Task<DockerApiResponse> MakeRequestAsync(

--- a/src/Docker.DotNet/Models/ImageBuildParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ImageBuildParameters.Generated.cs
@@ -24,20 +24,11 @@ namespace Docker.DotNet.Models
         [QueryStringParameter("forcerm", false, typeof(BoolQueryStringConverter))]
         public bool? ForceRemove { get; set; }
 
-        [QueryStringParameter("pullparent", false, typeof(BoolQueryStringConverter))]
-        public bool? PullParent { get; set; }
-
         [QueryStringParameter("pull", false)]
         public string Pull { get; set; }
 
-        [QueryStringParameter("isolation", false)]
-        public string Isolation { get; set; }
-
         [QueryStringParameter("cpusetcpus", false)]
         public string CPUSetCPUs { get; set; }
-
-        [QueryStringParameter("cpusetmems", false)]
-        public string CPUSetMems { get; set; }
 
         [QueryStringParameter("cpushares", false)]
         public long? CPUShares { get; set; }
@@ -54,9 +45,6 @@ namespace Docker.DotNet.Models
         [QueryStringParameter("memswap", false)]
         public long? MemorySwap { get; set; }
 
-        [QueryStringParameter("cgroupparent", false)]
-        public string CgroupParent { get; set; }
-
         [QueryStringParameter("networkmode", false)]
         public string NetworkMode { get; set; }
 
@@ -65,9 +53,6 @@ namespace Docker.DotNet.Models
 
         [QueryStringParameter("dockerfile", false)]
         public string Dockerfile { get; set; }
-
-        [QueryStringParameter("ulimits", false, typeof(EnumerableQueryStringConverter))]
-        public IList<Ulimit> Ulimits { get; set; }
 
         [QueryStringParameter("buildargs", false, typeof(MapQueryStringConverter))]
         public IDictionary<string, string> BuildArgs { get; set; }
@@ -81,17 +66,11 @@ namespace Docker.DotNet.Models
         [QueryStringParameter("cachefrom", false, typeof(EnumerableQueryStringConverter))]
         public IList<string> CacheFrom { get; set; }
 
-        [QueryStringParameter("securityopt", false, typeof(EnumerableQueryStringConverter))]
-        public IList<string> SecurityOpt { get; set; }
-
         [QueryStringParameter("extrahosts", false, typeof(EnumerableQueryStringConverter))]
         public IList<string> ExtraHosts { get; set; }
 
         [QueryStringParameter("target", false)]
         public string Target { get; set; }
-
-        [QueryStringParameter("session", false)]
-        public string SessionID { get; set; }
 
         [QueryStringParameter("platform", false)]
         public string Platform { get; set; }

--- a/tools/specgen/modeldefs.go
+++ b/tools/specgen/modeldefs.go
@@ -5,7 +5,6 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
-	"github.com/docker/go-units"
 )
 
 // Args map
@@ -19,29 +18,22 @@ type ImageBuildParameters struct {
 	NoCache        bool                        `rest:"query"`
 	Remove         bool                        `rest:"query,rm"`
 	ForceRemove    bool                        `rest:"query,forcerm"`
-	PullParent     bool                        `rest:"query"`
 	Pull           string                      `rest:"query"`
-	Isolation      string                      `rest:"query"`
 	CPUSetCPUs     string                      `rest:"query"`
-	CPUSetMems     string                      `rest:"query"`
 	CPUShares      int64                       `rest:"query"`
 	CPUQuota       int64                       `rest:"query"`
 	CPUPeriod      int64                       `rest:"query"`
 	Memory         int64                       `rest:"query"`
 	MemorySwap     int64                       `rest:"query,memswap"`
-	CgroupParent   string                      `rest:"query"`
 	NetworkMode    string                      `rest:"query"`
 	ShmSize        int64                       `rest:"query"`
 	Dockerfile     string                      `rest:"query"`
-	Ulimits        []*units.Ulimit             `rest:"query"`
 	BuildArgs      map[string]string           `rest:"query"`
 	Labels         map[string]string           `rest:"query"`
 	Squash         bool                        `rest:"query"`
 	CacheFrom      []string                    `rest:"query"`
-	SecurityOpt    []string                    `rest:"query"`
 	ExtraHosts     []string                    `rest:"query"`
 	Target         string                      `rest:"query"`
-	SessionID      string                      `rest:"query,session"`
 	Platform       string                      `rest:"query"`
 	Outputs        string                      `rest:"query"`
 	AuthConfigs    map[string]types.AuthConfig `rest:"headers,X-Registry-Config"`


### PR DESCRIPTION
@galvesribeiro The first commit disposes the `HttpClient`. Usually, you would like to keep a single instance of the `HttpClient` for the entire application. I am not certain if that works with the current implementation. That's why I kept it as a non static field, disposing it makes sense then.

The second one removes the extra properties. I double-checked them against the API docs. `pull` and `outputs` where part of e43cdd96ef089ec20f99defb5b83b047e2bdec04 and detected by my script (as I said, I didn't really check the other way around).

Closes #518, closes  #522.
