### PR TITLE
fix: Sync Docker system monitor events

### DIFF
--- a/test/Docker.DotNet.Tests/IContainerOperationsTests.cs
+++ b/test/Docker.DotNet.Tests/IContainerOperationsTests.cs
@@ -13,7 +13,7 @@ using Xunit.Abstractions;
 namespace Docker.DotNet.Tests
 {
     [Collection(nameof(TestCollection))]
-    public class IContainerOperationsTests
+    public sealed class IContainerOperationsTests : IDisposable
     {
         private readonly CancellationTokenSource _cts;
 
@@ -807,6 +807,11 @@ namespace Docker.DotNet.Tests
 
             // Then
             Assert.Null(exception);
+        }
+
+        public void Dispose()
+        {
+            _cts.Dispose();
         }
     }
 }

--- a/test/Docker.DotNet.Tests/IContainerOperationsTests.cs
+++ b/test/Docker.DotNet.Tests/IContainerOperationsTests.cs
@@ -107,6 +107,8 @@ namespace Docker.DotNet.Tests
                 _cts.Token
             );
 
+            await Task.Delay(TimeSpan.FromSeconds(5), default);
+
             containerLogsCts.CancelAfter(TimeSpan.FromSeconds(5));
 
             var containerLogsTask = _dockerClient.Containers.GetContainerLogsAsync(
@@ -153,6 +155,8 @@ namespace Docker.DotNet.Tests
                 new ContainerStartParameters(),
                 _cts.Token
             );
+
+            await Task.Delay(TimeSpan.FromSeconds(5), default);
 
             containerLogsCts.CancelAfter(TimeSpan.FromSeconds(5));
 
@@ -203,6 +207,8 @@ namespace Docker.DotNet.Tests
                 _cts.Token
             );
 
+            await Task.Delay(TimeSpan.FromSeconds(5), default);
+
             containerLogsCts.CancelAfter(TimeSpan.FromSeconds(5));
 
             var containerLogsTask = _dockerClient.Containers.GetContainerLogsAsync(
@@ -215,10 +221,8 @@ namespace Docker.DotNet.Tests
                     Follow = false
                 },
                 containerLogsCts.Token,
-                new Progress<string>(m => { _output.WriteLine(m); logList.Add(m); })
+                new Progress<string>(m => { logList.Add(m); _output.WriteLine(m); })
             );
-
-            await Task.Delay(TimeSpan.FromSeconds(5));
 
             await _dockerClient.Containers.StopContainerAsync(
                 createContainerResponse.ID,
@@ -253,9 +257,11 @@ namespace Docker.DotNet.Tests
                 _cts.Token
             );
 
+            await Task.Delay(TimeSpan.FromSeconds(5), default);
+
             containerLogsCts.CancelAfter(TimeSpan.FromSeconds(5));
 
-            await Assert.ThrowsAsync<TaskCanceledException>(() => _dockerClient.Containers.GetContainerLogsAsync(
+            var containerLogsTask = _dockerClient.Containers.GetContainerLogsAsync(
                 createContainerResponse.ID,
                 new ContainerLogsParameters
                 {
@@ -266,7 +272,9 @@ namespace Docker.DotNet.Tests
                 },
                 containerLogsCts.Token,
                 new Progress<string>(m => _output.WriteLine(m))
-            ));
+            );
+
+            await Assert.ThrowsAsync<TaskCanceledException>(() => containerLogsTask);
         }
 
         [Fact]
@@ -289,6 +297,8 @@ namespace Docker.DotNet.Tests
                 new ContainerStartParameters(),
                 _cts.Token
             );
+
+            await Task.Delay(TimeSpan.FromSeconds(5), default);
 
             containerLogsCts.CancelAfter(TimeSpan.FromSeconds(5));
 
@@ -330,6 +340,8 @@ namespace Docker.DotNet.Tests
                 _cts.Token
             );
 
+            await Task.Delay(TimeSpan.FromSeconds(5), default);
+
             containerLogsCts.CancelAfter(TimeSpan.FromSeconds(5));
 
             var containerLogsTask = _dockerClient.Containers.GetContainerLogsAsync(
@@ -342,17 +354,8 @@ namespace Docker.DotNet.Tests
                     Follow = true
                 },
                 containerLogsCts.Token,
-                new Progress<string>(m => { _output.WriteLine(m); logList.Add(m); })
+                new Progress<string>(m => { logList.Add(m); _output.WriteLine(m); })
             );
-
-            await Task.Delay(TimeSpan.FromSeconds(5));
-
-            await _dockerClient.Containers.StopContainerAsync(
-                createContainerResponse.ID,
-                new ContainerStopParameters(),
-                _cts.Token
-            );
-
 
             await Assert.ThrowsAsync<TaskCanceledException>(() => containerLogsTask);
             _output.WriteLine($"Line count: {logList.Count}");

--- a/test/Docker.DotNet.Tests/IImageOperationsTests.cs
+++ b/test/Docker.DotNet.Tests/IImageOperationsTests.cs
@@ -9,7 +9,7 @@ using Xunit.Abstractions;
 namespace Docker.DotNet.Tests
 {
     [Collection(nameof(TestCollection))]
-    public class IImageOperationsTests
+    public sealed class IImageOperationsTests : IDisposable
     {
         private readonly CancellationTokenSource _cts;
 
@@ -34,7 +34,7 @@ namespace Docker.DotNet.Tests
         }
 
         [Fact]
-        public async Task CreateImageAsync_TaskCancelled_ThowsTaskCanceledException()
+        public async Task CreateImageAsync_TaskCancelled_ThrowsTaskCanceledException()
         {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token);
 
@@ -113,6 +113,11 @@ namespace Docker.DotNet.Tests
 
             Assert.NotNull(inspectExistingImageResponse);
             await Assert.ThrowsAsync<DockerImageNotFoundException>(() => inspectDeletedImageTask);
+        }
+
+        public void Dispose()
+        {
+            _cts.Dispose();
         }
     }
 }

--- a/test/Docker.DotNet.Tests/ISystemOperations.Tests.cs
+++ b/test/Docker.DotNet.Tests/ISystemOperations.Tests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -13,7 +12,7 @@ using Xunit.Abstractions;
 namespace Docker.DotNet.Tests
 {
     [Collection(nameof(TestCollection))]
-    public class ISystemOperationsTests
+    public sealed class ISystemOperationsTests : IDisposable
     {
         private readonly CancellationTokenSource _cts;
 
@@ -259,7 +258,15 @@ namespace Docker.DotNet.Tests
         [Fact]
         public async Task PingAsync_Succeeds()
         {
-            await _dockerClient.System.PingAsync();
+            var exception = await Record.ExceptionAsync(() => _dockerClient.System.PingAsync())
+                .ConfigureAwait(false);
+
+            Assert.Null(exception);
+        }
+
+        public void Dispose()
+        {
+            _cts.Dispose();
         }
     }
 }

--- a/test/Docker.DotNet.Tests/IVolumeOperationsTests.cs
+++ b/test/Docker.DotNet.Tests/IVolumeOperationsTests.cs
@@ -4,14 +4,13 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Docker.DotNet.Models;
-using Newtonsoft.Json;
 using Xunit;
 using Xunit.Abstractions;
 
 namespace Docker.DotNet.Tests
 {
 	[Collection(nameof(TestCollection))]
-	public class IVolumeOperationsTests
+	public sealed class IVolumeOperationsTests : IDisposable
 	{
 		private readonly CancellationTokenSource _cts;
 
@@ -54,6 +53,11 @@ namespace Docker.DotNet.Tests
 			{
 				await _dockerClient.Volumes.RemoveAsync(volumeName, force: true, _cts.Token);
 			}
+		}
+
+		public void Dispose()
+		{
+			_cts.Dispose();
 		}
 	}
 }

--- a/test/Docker.DotNet.Tests/TestFixture.cs
+++ b/test/Docker.DotNet.Tests/TestFixture.cs
@@ -16,11 +16,11 @@ namespace Docker.DotNet.Tests
         /// The Docker image name.
         /// </summary>
         private const string Name = "nats";
-        
+
         private static readonly Progress<JSONMessage> WriteProgressOutput;
 
         private bool _hasInitializedSwarm;
-        
+
         static TestFixture()
         {
             WriteProgressOutput = new Progress<JSONMessage>(jsonMessage =>
@@ -30,7 +30,7 @@ namespace Docker.DotNet.Tests
                 Debug.WriteLine(message);
             });
         }
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TestFixture" /> class.
         /// </summary>
@@ -39,7 +39,7 @@ namespace Docker.DotNet.Tests
         {
             DockerClientConfiguration = new DockerClientConfiguration();
             DockerClient = DockerClientConfiguration.CreateClient();
-            Cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+            Cts = new CancellationTokenSource(TimeSpan.FromMinutes(10));
             Cts.Token.Register(() => throw new TimeoutException("Docker.DotNet test timeout exception"));
         }
 

--- a/test/Docker.DotNet.Tests/TestOutput.cs
+++ b/test/Docker.DotNet.Tests/TestOutput.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using Xunit.Abstractions;
 
 namespace Docker.DotNet.Tests
@@ -15,8 +16,8 @@ namespace Docker.DotNet.Tests
         public void WriteLine(string line)
         {
             Console.WriteLine(line);
+            Debug.WriteLine(line);
             _outputHelper.WriteLine(line);
-            System.Diagnostics.Debug.WriteLine(line);
         }
     }
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

Synchronizes the Docker system event tests with the help of `AutoResetEvent`. At least two tests (`MonitorEventsAsync_IsCancelled_NoStreamCorruption` and `MonitorEventsFiltered_Succeeds`) do not synchronize the events. The tests are not deterministic, they might run into a race condition where events are not published on assertions yet.

## Why is it important?

Some `Docker.DotNet` tests are flaky, PR improves the reliability of the tests.

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
- Relates #599

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

## Follow-ups

- Looking closer into the tests, I noticed (gut feeling) events triggered, quickly after another might not be published reliable. It looks like they are swallowed.
- I think we can reduce the complexity of `StreamUtil`.
- /cc @dgvives You might want to take a look at the _stream corruption_ test changes.
