### PR TITLE
fix: Do not read from stream with content length of 0

### DIFF
--- a/src/Docker.DotNet/Microsoft.Net.Http.Client/ContentLengthReadStream.cs
+++ b/src/Docker.DotNet/Microsoft.Net.Http.Client/ContentLengthReadStream.cs
@@ -93,6 +93,12 @@ namespace Microsoft.Net.Http.Client
             {
                 return 0;
             }
+
+            if (_bytesRemaining == 0)
+            {
+                return 0;
+            }
+
             int toRead = (int)Math.Min(count, _bytesRemaining);
             int read = _inner.Read(buffer, offset, toRead);
             UpdateBytesRemaining(read);
@@ -106,6 +112,12 @@ namespace Microsoft.Net.Http.Client
             {
                 return 0;
             }
+
+            if (_bytesRemaining == 0)
+            {
+                return 0;
+            }
+
             cancellationToken.ThrowIfCancellationRequested();
             int toRead = (int)Math.Min(count, _bytesRemaining);
             int read = await _inner.ReadAsync(buffer, offset, toRead, cancellationToken);


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the existing labels, depending on the scope of your change.
-->

## What does this PR do?

The pull request addresses an issue where `Docker.DotNet` throws a `SocketException` when attempting to read from a stream that has an initial content length of 0 bytes.

## Why is it important?

The Podman container runtime produces a slightly different HTTP response for the HTTP PUT API `/containers/{id}/archive`, where it sets the `Content-Length` field to 0.

**Docker**

```
< HTTP/1.1 200 OK
< Api-Version: 1.41
< Date: Wed, 26 Apr 2023 18:04:19 GMT
< Docker-Experimental: false
< Ostype: linux
< Server: Docker/20.10.23 (linux)
< Transfer-Encoding: chunked
<
```

**Podman**

```
< HTTP/1.1 200 OK
< Api-Version: 1.41
< Libpod-Api-Version: 4.5.0
< Server: Libpod/4.5.0 (linux)
< X-Reference-Id: 0x400067c368
< Date: Wed, 26 Apr 2023 18:27:51 GMT
< Content-Length: 0
<
```

`Docker.DotNet` does not consider the initial content length and instead tries to read from the stream, resulting in `System.Net.Http.HttpRequestException : Error while copying content to a stream`. Since the content length is 0, it is acceptable for Podman to terminate the HTTP connection.

```
  Error Message:
   System.Net.Http.HttpRequestException : Error while copying content to a stream.
---- System.IO.IOException : Unable to read data from the transport connection: Connection reset by peer.
-------- System.Net.Sockets.SocketException : Connection reset by peer
  Stack Trace:
     at System.Net.Http.HttpContent.LoadIntoBufferAsyncCore(Task serializeToStreamTask, MemoryStream tempBuffer)
   at System.Net.Http.HttpClient.<SendAsync>g__Core|83_0(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationTokenSource cts, Boolean disposeCts, CancellationTokenSource pendingRequestsCts, CancellationToken originalCancellationToken)
   at Docker.DotNet.DockerClient.PrivateMakeRequestAsync(TimeSpan timeout, HttpCompletionOption completionOption, HttpMethod method, String path, IQueryString queryString, IDictionary`2 headers, IRequestContent data, CancellationToken cancellationToken)
   at Docker.DotNet.DockerClient.MakeRequestAsync(IEnumerable`1 errorHandlers, HttpMethod method, String path, IQueryString queryString, IRequestContent body, IDictionary`2 headers, TimeSpan timeout, CancellationToken token)
----- Inner Stack Trace -----
   at Microsoft.Net.Http.Client.ContentLengthReadStream.ReadAsync(Byte[] buffer, Int32 offset, Int32 count, CancellationToken cancellationToken)
   at System.IO.Stream.<CopyToAsync>g__Core|29_0(Stream source, Stream destination, Int32 bufferSize, CancellationToken cancellationToken)
   at System.Net.Http.HttpContent.LoadIntoBufferAsyncCore(Task serializeToStreamTask, MemoryStream tempBuffer)
----- Inner Stack Trace -----
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->