### PR TITLE
feat: Update to Docker v24.0.2

### DIFF
--- a/tools/specgen/go.mod
+++ b/tools/specgen/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/docker v20.10.17+incompatible
+	github.com/docker/docker v24.0.2+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0
 	github.com/gogo/protobuf v1.3.1 // indirect

--- a/tools/specgen/go.sum
+++ b/tools/specgen/go.sum
@@ -12,6 +12,8 @@ github.com/docker/docker v20.10.2+incompatible h1:vFgEHPqWBTp4pTjdLwjAA4bSo3gvIG
 github.com/docker/docker v20.10.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.17+incompatible h1:JYCuMrWaVNophQTOrMMoSwudOVEfcegoZZrleKc1xwE=
 github.com/docker/docker v20.10.17+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.2+incompatible h1:eATx+oLz9WdNVkQrr0qjQ8HvRJ4bOOxfzEo8R+dA3cg=
+github.com/docker/docker v24.0.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=

--- a/tools/specgen/modeldefs.go
+++ b/tools/specgen/modeldefs.go
@@ -5,6 +5,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/api/types/network"
 	"github.com/docker/docker/api/types/swarm"
+	"github.com/docker/docker/api/types/volume"
 )
 
 // Args map
@@ -165,7 +166,7 @@ type ContainerUpdateResponse struct {
 }
 
 // ContainerWaitResponse for POST /containers/(id)/wait
-type ContainerWaitResponse container.ContainerWaitOKBody
+type ContainerWaitResponse container.WaitResponse
 
 // ContainerEventsParameters for GET /events
 type ContainerEventsParameters struct {
@@ -330,7 +331,7 @@ type VolumesPruneParameters struct {
 }
 
 // VolumeResponse for GET /volumes
-type VolumeResponse types.Volume
+type VolumeResponse volume.Volume
 
 // VolumesListResponse for GET /volumes
 type VolumesListResponse struct {

--- a/tools/specgen/specgen.go
+++ b/tools/specgen/specgen.go
@@ -37,7 +37,7 @@ var typesToDisambiguate = map[string]*CSModelType{
 			},
 		},
 	},
-	typeToKey(reflect.TypeOf(container.ContainerCreateCreatedBody{})): {Name: "CreateContainerResponse"},
+	typeToKey(reflect.TypeOf(container.CreateResponse{})): {Name: "CreateContainerResponse"},
 	typeToKey(reflect.TypeOf(container.HealthConfig{})): {
 		Properties: []CSProperty{
 			CSProperty{
@@ -177,7 +177,7 @@ var dockerTypesToReflect = []reflect.Type{
 
 	// POST /containers/create
 	reflect.TypeOf(CreateContainerParameters{}),
-	reflect.TypeOf(container.ContainerCreateCreatedBody{}),
+	reflect.TypeOf(container.CreateResponse{}),
 
 	// GET /containers/json
 	reflect.TypeOf(ContainersListParameters{}),
@@ -719,9 +719,19 @@ func main() {
 		reflectType(t)
 	}
 
-	for k, v := range reflectedTypes {
-		if _, e := os.Stat(path.Join(sourcePath, v.Name+".Generated.cs")); e == nil {
-			panic(fmt.Sprintf("File: (%s.Generated.cs) already exists. Failed to write key same name for key: (%s) type: (%s).", v.Name, k, v.SourceName))
+	for _, v := range reflectedTypes {
+		// if _, e := os.Stat(path.Join(sourcePath, v.Name+".Generated.cs")); e == nil {
+		// 	panic(fmt.Sprintf("File: (%s.Generated.cs) already exists. Failed to write key same name for key: (%s) type: (%s).", v.Name, k, v.SourceName))
+		// }
+
+		// TODO: Validate the generated file name class for Swarm.Info, Swarm.Secret, Swarm.Topology, etc.
+
+		var className string
+
+		if _, e := os.Stat(path.Join(sourcePath, v.Name + ".Generated.cs")); e == nil {
+			className = strings.Title(v.SourceName) + ".Generated.cs"
+		} else {
+			className = v.Name + ".Generated.cs"
 		}
 
 		f, err := ioutil.TempFile(sourcePath, "ser")
@@ -740,6 +750,6 @@ func main() {
 		}
 
 		f.Close()
-		os.Rename(f.Name(), path.Join(sourcePath, v.Name+".Generated.cs"))
+		os.Rename(f.Name(), path.Join(sourcePath, className))
 	}
 }


### PR DESCRIPTION
## What does this PR do?

The pull request updates Moby to its latest version, [v24.0.2](https://github.com/moby/moby/releases/tag/v24.0.2). A few classes have been renamed:

- https://github.com/moby/moby/commit/72938574568461ee5e544459a779c5fd4ac14103
- https://github.com/moby/moby/commit/3bb2d0026b9353e02a011fc64c821534bd1cae36
- https://github.com/moby/moby/commit/f19ef20a4414a6f63da8fb2493e6010359652ad1

This change https://github.com/moby/moby/commit/240a9fcb833996b1365266b906e181a1a6e06549 requires probably slightly more adjustments. `specgen` fails to generate structs because the file name clashes. Specifically the Info, Secret and Topology structs for swarm and volume.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale / motivation for the changes.
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Supersedes #123
-->
\-

<!-- Recommended
## How to test this PR

Explain here how this PR will be tested by the reviewer: commands, dependencies, steps, etc.
-->

<!-- Optional
## Follow-ups

Add here any thought that you consider could be identified as an actionable step once this PR is merged.
-->