### PR TITLE
[Container Attach] Wrong property data type

### DIFF
--- a/src/Docker.DotNet/Models/ContainerAttachParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerAttachParameters.Generated.cs
@@ -21,6 +21,6 @@ namespace Docker.DotNet.Models
         public string DetachKeys { get; set; }
 
         [QueryStringParameter("logs", false)]
-        public string Logs { get; set; }
+        public bool? Logs { get; set; }
     }
 }


### PR DESCRIPTION
Fixed the wrong data type used for Logs as referred in the official Docker Engine api.

Logs property should be boolean instead of string

(https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerAttach)