### PR TITLE
[Container Attach] Wrong data type used for Logs property

### DIFF
--- a/src/Docker.DotNet/Models/ContainerAttachParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerAttachParameters.Generated.cs
@@ -21,6 +21,6 @@ namespace Docker.DotNet.Models
         public string DetachKeys { get; set; }
 
         [QueryStringParameter("logs", false)]
-        public string Logs { get; set; }
+        public bool? Logs { get; set; }
     }
 }

--- a/tools/specgen/modeldefs.go
+++ b/tools/specgen/modeldefs.go
@@ -94,8 +94,8 @@ type ContainerAttachParameters struct {
 	Stdin      bool   `rest:"query"`
 	Stdout     bool   `rest:"query"`
 	Stderr     bool   `rest:"query"`
-	DetachKeys string `rest:"query,detachKeys"`
-	Logs       string `rest:"query"`
+	Logs       bool `rest:"query"`
+	DetachKeys string `rest:"query,detachKeys"`	
 }
 
 // ContainerInspectParameters for GET /containers/(id)/json


### PR DESCRIPTION
As referred in the api (https://docs.docker.com/engine/api/v1.41/#tag/Container/operation/ContainerAttach)
The data type of the Logs property should be a boolean.