### PR TITLE
Add support for handling systemerr stream from daemon

### DIFF
--- a/src/Docker.DotNet/Daemon/DockerDaemonException.cs
+++ b/src/Docker.DotNet/Daemon/DockerDaemonException.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Docker.DotNet.Daemon
+{
+    public class DockerDaemonException : Exception
+    {
+        public DockerDaemonException(string message) : base($"error from daemon in stream: {message}")
+        {
+        }
+    }
+}

--- a/test/Docker.DotNet.Tests/MultiplexedStreamTests.cs
+++ b/test/Docker.DotNet.Tests/MultiplexedStreamTests.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Docker.DotNet.Daemon;
+using Xunit;
+
+namespace Docker.DotNet.Tests;
+
+public class MultiplexedStreamTests
+{
+    [Fact]
+    public async Task WriteToDifferentStreams_CopyOutputToAsync_DividedStreams()
+    {
+        using var source = new MemoryStream();
+        using var stdout = new MemoryStream();
+        using var stderr = new MemoryStream();
+        using var stream = new MultiplexedStream(source, multiplexed: true);
+
+        await WriteMessage(source, MultiplexedStream.TargetStream.StandardOut, "information");
+        await WriteMessage(source, MultiplexedStream.TargetStream.StandardError, "some error");
+
+        source.Seek(0, SeekOrigin.Begin);
+        await stream.CopyOutputToAsync(Stream.Null, stdout, stderr, CancellationToken.None);
+
+        stdout.Seek(0, SeekOrigin.Begin);
+        using (var reader = new StreamReader(stdout))
+            Assert.Equal("information", await reader.ReadToEndAsync());
+
+        stderr.Seek(0, SeekOrigin.Begin);
+        using (var reader = new StreamReader(stderr))
+            Assert.Equal("some error", await reader.ReadToEndAsync());
+    }
+
+    [Fact]
+    public async Task WriteToSystemError_CopyOutputToAsync_ThrowAnExceptionWithReceivedMessage()
+    {
+        using var source = new MemoryStream();
+        using var stream = new MultiplexedStream(source, multiplexed: true);
+
+        await WriteMessage(source, MultiplexedStream.TargetStream.SystemError, "failed to grab logs");
+
+        source.Seek(0, SeekOrigin.Begin);
+        var exception = Assert.Throws<DockerDaemonException>(() =>
+        {
+            stream
+                .CopyOutputToAsync(Stream.Null, Stream.Null, Stream.Null, CancellationToken.None)
+                .GetAwaiter()
+                .GetResult();
+        });
+
+        Assert.Contains("failed to grab logs", exception.Message);
+    }
+
+    private static async Task WriteHeaderAsync(Stream stream, MultiplexedStream.TargetStream target, int length)
+    {
+        var header = new byte[8];
+        header[0] = (byte)target;
+        header[4] = (byte)(length >> 24 & 0xFF);
+        header[5] = (byte)(length >> 16 & 0xFF);
+        header[6] = (byte)(length >> 8 & 0xFF);
+        header[7] = (byte)(length >> 0 & 0xFF);
+        await stream.WriteAsync(header);
+    }
+
+    private static async Task WriteMessage(Stream stream, MultiplexedStream.TargetStream target, string message)
+    {
+        var messageBody = Encoding.UTF8.GetBytes(message);
+        await WriteHeaderAsync(stream, target, messageBody.Length);
+        await stream.WriteAsync(messageBody);
+    }
+}


### PR DESCRIPTION
### Context

In the current version of Docker.DotNet (v3.125.15), there is no support for handling the [Systemerr](https://pkg.go.dev/github.com/docker/docker/pkg/stdcopy#StdType) stream when demultiplexing events from Docker.  
When docker sends `Systemerr`, the library throws an `IOException` with the message "unknown stream type"  

### Reproduce

To reproduce this issue, we have a valid container `f13d4aec`

```
root@domain:~# docker logs f13d4aec
{truncated}
2024-06-27 09:27:37.337196+00:00 [info] <0.683.0>  * rabbitmq_management_agent
2024-06-27 09:27:37.337196+00:00 [info] <0.683.0>  * rabbitmq_web_dispatch
2024-06-27 09:27:37.803052+00:00 [info] <0.9.0> Time to start RabbitMQ: 12848 ms
root@domain:~# echo $?
0
```

#### Steps

1. Break json in logs to simulate a scenario where Docker would send a `SystemErr`
   ```bash
   echo -e "\n{invalid_json\n" > /var/lib/docker/containers/{containerId}/{containerId}-json.log
   ```

2. Ensure that `docker logs` command exited with non-zero code
   ```
   root@domain:~# docker logs f13d4aec
   error from daemon in stream: Error grabbing logs: invalid character 'i' looking for beginning of object key string
   
   root@domain:~# echo $?
   1
   ```

3. Using the library to view logs
   ```cs
   using Docker.DotNet;
   using Docker.DotNet.Models;
   
   var client = new DockerClientConfiguration(
           new Uri("http://192.168.1.189:2375"))
       .CreateClient();
   
   var response = await client.Containers.GetContainerLogsAsync("f13d4aec", false, new ContainerLogsParameters()
   {
       ShowStdout = true
   });
   
   var (stdout, stderr) = await response.ReadOutputToEndAsync(CancellationToken.None);
   ```
   
   This will throw an exception
   ```
   System.IO.IOException: unknown stream type
   ```

### Changes

Therefore, this PR introduces a new handler for `Systemerr` stream within Docerk.DotNet.  
It reads the message and throws a `DockerDaemonException` instead of the generic `IOException`  
The message in the exception was completely copied from [moby's behavior](https://github.com/moby/moby/blob/47eebd718f332f29a38455b61ee879ced5bc219b/pkg/stdcopy/stdcopy.go#L170) to provide clear guidance on troubleshooting known issues

Now the exception will look like this
```
Docker.DotNet.Daemon.DockerDaemonException: error from daemon in stream: Error grabbing logs: invalid character 'i' looking for beginning of object key string
```
