### PR TITLE
Add copyUIDGID to ContainerPathStatParameters

### DIFF
--- a/src/Docker.DotNet/Models/ContainerPathStatParameters.Generated.cs
+++ b/src/Docker.DotNet/Models/ContainerPathStatParameters.Generated.cs
@@ -10,5 +10,8 @@ namespace Docker.DotNet.Models
 
         [QueryStringParameter("noOverwriteDirNonDir", false, typeof(BoolQueryStringConverter))]
         public bool? AllowOverwriteDirWithFile { get; set; }
+
+        [QueryStringParameter("copyUIDGID", false, typeof(BoolQueryStringConverter))]
+        public bool? CopyUidAndGid { get; set; }
     }
 }

--- a/tools/specgen/modeldefs.go
+++ b/tools/specgen/modeldefs.go
@@ -86,6 +86,7 @@ type ContainerRemoveParameters struct {
 type ContainerPathStatParameters struct {
 	Path                      string `rest:"query,path,required"`
 	AllowOverwriteDirWithFile bool   `rest:"query,noOverwriteDirNonDir"`
+	CopyUidAndGid bool   `rest:"query,copyUIDGID"`
 }
 
 // ContainerAttachParameters for POST /containers/(id)/attach


### PR DESCRIPTION
Allows extracting Tar balls with original owner. See spec [ContainerPathStatParameters](https://docs.docker.com/engine/api/v1.45/#tag/Container/operation/PutContainerArchive)