### PR TITLE
chore: Update CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 8.x
       - name: Build
         run: dotnet build -c Release
       - name: Test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,36 +10,25 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v2
+        uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 6.0.x
-      - name: Install SignClient tool
-        run: dotnet tool install --tool-path . SignClient
+          dotnet-version: 8.x
       - name: Install NBGV tool
         run: dotnet tool install --tool-path . nbgv
       - name: Set Version
         run: ./nbgv cloud
       - name: Create Packages
-        run: dotnet pack -c Release -o packages
-      - name: Sign Packages
-        run: |
-          echo $DNF_CODESIGN_CONFIG > ./packages/sign.json
-          ./SignClient sign --config "./packages/sign.json" --input "./packages/**/*.nupkg" --name "Docker.DotNet" --user "$DNF_CODESIGN_USER" --secret "$DNF_CODESIGN_SECRET" --Description "Docker.Net" --descriptionUrl "https://github.com/dotnet/Docker.DotNet"
-          rm packages/sign.json
-        env:
-          DNF_CODESIGN_CONFIG: ${{secrets.DNF_CODESIGN_CONFIG}}
-          DNF_CODESIGN_USER: ${{secrets.DNF_CODESIGN_USER}}
-          DNF_CODESIGN_SECRET: ${{secrets.DNF_CODESIGN_SECRET}}
+        run: dotnet pack -c Release -o packages -p:ContinuousIntegrationBuild=true
       - name: Push packages to NuGet.org
         run: dotnet nuget push ./packages/Docker.DotNet.*.nupkg --skip-duplicate -k ${{ secrets.NUGET_KEY }} -s https://api.nuget.org/v3/index.json
       - name: Create Release
-        uses: actions/github-script@v5
+        uses: actions/github-script@v7
         with:
           script: |
             github.rest.repos.createRelease({

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,7 @@
 <Project>
   <!-- Strong-naming  -->
   <PropertyGroup Label="Signing">
+    <DebugType>embedded</DebugType>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\Key.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-﻿# .NET Client for Docker Remote API
+﻿> [!IMPORTANT]  
+> Unfortunately, there has been no further development or bug fixes in [Docker.DotNet](https://github.com/dotnet/Docker.DotNet/tree/aacf3c26131f582ca8acc34084663a4b79e28d38) for some time now, and the repository appears inactive. Reaching the current maintainer is challenging. I understand that priorities shift, and maintaining an open-source project is time-consuming and exhausting. As maintainers, we often cannot dedicate the necessary time. Over the past months—and even years—I have frequently offered my help.
+> 
+> Docker.DotNet is an important upstream dependency for Testcontainers for .NET and many other developers. It would be unfortunate for this valuable work not to continue. Therefore, I have decided to fork the repository to focus on essential fixes, improvements, and updates for the Docker Engine API. I am also accepting further contributions and remaining PRs from the upstream repository.
+
+# .NET Client for Docker Remote API
 
 This library allows you to interact with [Docker Remote API][docker-remote-api]  endpoints in your .NET applications.
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
 
     <PropertyGroup>
         <IsPackable>true</IsPackable>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>net6.0;net8.0;netstandard2.0;netstandard2.1</TargetFrameworks>
         <PackageIconUrl>https://camo.githubusercontent.com/fa6d5c12609ed8a3ba1163b96f9e9979b8f59b0d/687474703a2f2f7765732e696f2f566663732f636f6e74656e74</PackageIconUrl>
         <Copyright>Copyright (c) .NET Foundation and Contributors</Copyright>
         <PackageTags>Docker Container C# .NET</PackageTags>
@@ -32,7 +32,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All"/>
         <PackageReference Include="Nerdbank.GitVersioning" Version="3.5.108">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/src/Docker.DotNet.BasicAuth/Docker.DotNet.BasicAuth.csproj
+++ b/src/Docker.DotNet.BasicAuth/Docker.DotNet.BasicAuth.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>    
-    <PackageId>Docker.DotNet.BasicAuth</PackageId>
+  <PropertyGroup>
+    <PackageId>Docker.DotNet.Enhanced.BasicAuth</PackageId>
     <Description>Docker.DotNet.BasicAuth is a library that allows you to use basic authentication with a remote Docker engine programmatically in your .NET applications.</Description>
     <AssemblyName>Docker.DotNet.BasicAuth</AssemblyName>
   </PropertyGroup>

--- a/src/Docker.DotNet.X509/Docker.DotNet.X509.csproj
+++ b/src/Docker.DotNet.X509/Docker.DotNet.X509.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsPackable>true</IsPackable>
-    <PackageId>Docker.DotNet.X509</PackageId>
+    <PackageId>Docker.DotNet.Enhanced.X509</PackageId>
     <Description>Docker.DotNet.X509 is a library that allows you to use certificate authentication with a remote Docker engine programmatically in your .NET applications.</Description>
     <AssemblyName>Docker.DotNet.X509</AssemblyName>
   </PropertyGroup>

--- a/src/Docker.DotNet/Docker.DotNet.csproj
+++ b/src/Docker.DotNet/Docker.DotNet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <PackageId>Docker.DotNet</PackageId>
+    <PackageId>Docker.DotNet.Enhanced</PackageId>
     <Description>Docker.DotNet is a library that allows you to interact with the Docker Remote API programmatically with fully asynchronous, non-blocking and object-oriented code in your .NET applications.</Description>
     <AssemblyName>Docker.DotNet</AssemblyName>
   </PropertyGroup>

--- a/test/Docker.DotNet.Tests/Docker.DotNet.Tests.csproj
+++ b/test/Docker.DotNet.Tests/Docker.DotNet.Tests.csproj
@@ -1,12 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsPublishable>false</IsPublishable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3"/>
-    <PackageReference Include="System.ServiceProcess.ServiceController" Version="5.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="xunit" Version="2.9.2" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Docker.DotNet.BasicAuth\Docker.DotNet.BasicAuth.csproj" />


### PR DESCRIPTION
Docker.DotNet is an important upstream dependency for Testcontainers for .NET and for many other developers. The project has become somewhat inactive, with no ongoing development or maintenance. Since it is important for Testcontainers for .NET, I decided to fork the project and replace the version used in Testcontainers for .NET with this one to ensure we can deliver important bug fixes and necessary changes as soon as possible. Additionally, I try to introduce further improvements to enhance the Docker Engine API client experience for .NET developers.